### PR TITLE
Add brew, apt providers & move header references to shim

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "CCairo"
+    name: "CCairo",
+    pkgConfig: "cairo",
+    providers: [.Brew("cairo"), .Apt("cairo")]
 )

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,8 +1,5 @@
 module CCairo [system] {
-    header "/usr/include/cairo/cairo.h"
-    header "/usr/include/cairo/cairo-pdf.h"
-    header "/usr/include/cairo/cairo-svg.h"
-    header "/usr/include/cairo/cairo-ft.h"
+    header "shim.h"
     link "cairo"
     export *
 }

--- a/shim.h
+++ b/shim.h
@@ -1,0 +1,4 @@
+#include <cairo.h>
+#include <cairo-pdf.h>
+#include <cairo-svg.h>
+#include <cairo-ft.h>


### PR DESCRIPTION
Allows using Cairo with Swift 3.1 on macOS Sierra 10.12.4 with Homebrew.

Contains changes originally created by @astrotuna201 (kudos).